### PR TITLE
Updated loader config and syncRequire

### DIFF
--- a/deft-citybars/app.js
+++ b/deft-citybars/app.js
@@ -9,7 +9,7 @@
 // This Loader config is used when running the app directly from the source, rather than a compiled build...
 //<debug>
 Ext.Loader.setPath({
-    'Ext': 'touch/src'
+    'Ext': 'touch/src',
     'Deft': 'packages/deft/src/js',
     'CityBars': 'app'
 });

--- a/deft-citybars/app.js
+++ b/deft-citybars/app.js
@@ -13,7 +13,7 @@ Ext.Loader.setPath({
     'Deft': 'packages/deft/src/js',
     'CityBars': 'app'
 });
-Ext.syncRequire(['Deft.mixin.Injectable','Deft.mixin.Controllable']);
+Ext.syncRequire(['Deft.mixin.Injectable','Deft.mixin.Controllable','Deft.promise.Chain']);
 //</debug>
 
 //@require Deft.mixin.Injectable


### PR DESCRIPTION
A comma added into the loader config and 'Deft.promise.Chain' added in to the 'Ext.syncRequire' to fix the issue with loadBusinessesForCurrentLocation() method in BusinessService.js causing 'Uncaught TypeError: Cannot call method 'sequence' of undefined' exception on Deft.Chain.sequence() call.
